### PR TITLE
Move gt from Imports to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ekioplot
 Type: Package
 Title: EKIO Visual Identity System for R Data Visualization
-Version: 0.4.0
+Version: 0.5.0
 Authors@R:
     person(
       "Vinicius", "Oike",
@@ -23,10 +23,10 @@ Imports:
     cli,
     ggplot2 (>= 3.5.0),
     grDevices,
-    gt,
     rlang
 Suggests:
     dplyr,
+    gt,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# ekioplot 0.5.0
+
+## Breaking changes
+
+* `gt` moved from `Imports` to `Suggests`. It is only needed by
+  `gt_theme_ekio()`, which now prompts to install it on first use via
+  `rlang::check_installed()`. This drops 43 transitive dependencies (including
+  `V8`, `Rcpp`, `curl`, `bslib`, `htmlwidgets`, `reactable`, `knitr`, and
+  `rmarkdown`) from a default install, leaving core plotting dependent only on
+  `ggplot2`'s tree. Users who style `gt` tables should add `gt` to their own
+  dependencies.
+
 # ekioplot 0.4.0
 
 ## Breaking changes

--- a/R/gt_theme.R
+++ b/R/gt_theme.R
@@ -13,13 +13,11 @@
 #' @return A styled gt table object
 #' @export
 #'
-#' @examples
-#' \dontrun{
+#' @examplesIf rlang::is_installed("gt")
 #' library(gt)
 #' head(mtcars, 10) |>
 #'   gt() |>
 #'   gt_theme_ekio()
-#' }
 gt_theme_ekio <- function(
   data,
   table_width = "100%",
@@ -27,6 +25,8 @@ gt_theme_ekio <- function(
   stripe = TRUE,
   add_footer = TRUE
 ) {
+  rlang::check_installed("gt", reason = "to style gt tables.")
+
   if (!inherits(data, "gt_tbl")) {
     cli::cli_abort("{.arg data} must be a gt table object")
   }

--- a/man/gt_theme_ekio.Rd
+++ b/man/gt_theme_ekio.Rd
@@ -30,10 +30,10 @@ A styled gt table object
 Professional EKIO branding and styling for gt table objects.
 }
 \examples{
-\dontrun{
+\dontshow{if (rlang::is_installed("gt")) withAutoprint(\{ # examplesIf}
 library(gt)
 head(mtcars, 10) |>
   gt() |>
   gt_theme_ekio()
-}
+\dontshow{\}) # examplesIf}
 }

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -178,7 +178,7 @@ ekio_accent
 
 Apply EKIO styling to gt tables with `gt_theme_ekio()`:
 
-```{r gt-theme}
+```{r gt-theme, eval = requireNamespace("gt", quietly = TRUE)}
 library(gt)
 
 head(mtcars[, 1:5], 8) |>


### PR DESCRIPTION
## Summary

`gt` is only used by `gt_theme_ekio()`, yet it sat in `Imports`, pulling **43 transitive dependencies** (V8, Rcpp, curl, bslib, htmlwidgets, reactable, knitr, rmarkdown, …) into every install. Everything else in `Imports` (`cli`, `rlang`, `grDevices`) is already in `ggplot2`'s tree at zero marginal cost, so `gt` was the only real weight.

This moves `gt` to `Suggests`, making the default install dependent only on `ggplot2`'s tree.

## Changes

- **DESCRIPTION** — `gt` `Imports` → `Suggests`; version `0.4.0` → `0.5.0`.
- **R/gt_theme.R** — `gt_theme_ekio()` now calls `rlang::check_installed("gt", ...)` up front; example switched to `@examplesIf rlang::is_installed("gt")`.
- **vignettes/getting-started.Rmd** — gt chunk now `eval = requireNamespace("gt", quietly = TRUE)` (conditional use of a suggested package).
- **NEWS.md** — breaking-change entry under 0.5.0.
- Regenerated `man/gt_theme_ekio.Rd`.

## Notes

- **Breaking:** users who style `gt` tables must now declare `gt` themselves.
- Tests already used `skip_if_not_installed("gt")`, so no test changes were needed.
- `R CMD check`: 0 errors / 0 warnings / 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)