### PR TITLE
Deprecate show_all_ekio_palettes() in favor of list_ekio_palettes(verbose = TRUE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,19 @@ R package implementing EKIO's visual identity system for ggplot2 and gt tables.
 ## Description
 A comprehensive R package that provides EKIO-branded themes, color palettes, scale functions, high-level "recipe" chart functions, and gt table theming for professional data visualizations. Follows EKIO design principles of clarity, purposeful color usage, and professional presentation standards.
 
+## Brand tokens (canonical)
+
+This package is EKIO's single source of truth for brand color and type. Downstream projects (the `ekio` workspace, `ekio-site`) mirror these — update here first.
+
+- **Colors**: `ekio_blue["700"]` = `#1E3A5F` (primary), `ekio_gray["900"]` = `#1A202C` (ink), `ekio_gray["50"]` = `#FAFBFC` (background); accents orange `#DD6B20`, teal `#2C7A7B`. Full 10-step scales in `R/colors.R`.
+- **Type — charts & gt tables**: Helvetica Neue (macOS) / Arial (Windows) via `.get_ekio_font()`; sans only, no serif in ggplot2/gt output.
+- **Type — web (ekio-site)**: Lora (serif display/headings), Lato (body), Fira Code (mono). Lora is a deliberate web-only editorial display font; it is intentionally *not* used in chart output, which stays on the sans stack above.
+
 ## Package Architecture
 
 ### Source Files (R/)
-- **colors.R** — Color scale vectors (`ekio_blue`, `ekio_gray`, `ekio_teal`, `ekio_orange`, `ekio_accent`), internal sequential/diverging palette lists, `ekio_pal()` palette accessor, `list_ekio_palettes()`, `show_ekio_palette()`, `show_all_ekio_palettes()`
+- **colors.R** — Color scale vectors (`ekio_blue`, `ekio_gray`, `ekio_teal`, `ekio_orange`, `ekio_accent`), internal sequential/diverging palette lists, `ekio_pal()` palette accessor, `list_ekio_palettes()`, `show_ekio_palette()`, `show_all_ekio_palettes()` (deprecated, use `list_ekio_palettes(verbose = TRUE)`)
+
 - **scales.R** — Discrete (`scale_color_ekio_d`, `scale_fill_ekio_d`) and continuous (`scale_color_ekio_c`, `scale_fill_ekio_c`) ggplot2 scale functions with British spelling aliases
 - **theme.R** — `theme_ekio()` (modular, uses `theme_sub_*` helpers) and `theme_ekio_map()` for spatial maps. Platform-aware font selection via `.get_ekio_font()`
 - **recipes.R** — High-level chart builders (`ekio_histogram`, `ekio_lineplot`, `ekio_scatterplot`, `ekio_barplot`) with smart aesthetic detection (static color vs. variable mapping)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ekioplot
 Type: Package
 Title: EKIO Visual Identity System for R Data Visualization
-Version: 0.5.0
+Version: 0.6.0
 Authors@R:
     person(
       "Vinicius", "Oike",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ekioplot 0.6.0
+
+## Breaking changes
+
+* `show_all_ekio_palettes()` is now deprecated. Use `list_ekio_palettes(verbose = TRUE)` instead.
+
 # ekioplot 0.5.0
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,15 @@
 # ekioplot 0.6.0
 
-## Breaking changes
+## New features
 
-* `show_all_ekio_palettes()` is now deprecated. Use `list_ekio_palettes(verbose = TRUE)` instead.
+* `list_ekio_palettes()` gains a `verbose` argument that prints a formatted
+  summary of the selected palette type(s).
+
+## Deprecations
+
+* `show_all_ekio_palettes()` is deprecated in favor of
+  `list_ekio_palettes(verbose = TRUE)`. It still works but warns once per
+  session, and is no longer listed on the pkgdown reference index.
 
 # ekioplot 0.5.0
 

--- a/R/colors.R
+++ b/R/colors.R
@@ -261,19 +261,24 @@ ekio_pal <- function(palette = "contrast", n = NULL, reverse = FALSE) {
 #' List Available Palettes
 #'
 #' Returns names of all available palettes, optionally filtered by type.
+#' When \code{verbose = TRUE}, prints a formatted summary to the console.
 #'
 #' @param type Character. Type of palettes to list:
 #'   "categorical", "small_group", "scientific", "sequential", "diverging",
 #'   or "all" (default).
+#' @param verbose Logical. If TRUE, prints a formatted summary organized by
+#'   type instead of returning a value (default: FALSE).
 #'
-#' @return Character vector of palette names, or named list if type = "all"
+#' @return Character vector of palette names, or named list if type = "all".
+#'   Invisibly returned when \code{verbose = TRUE}.
 #' @export
 #'
 #' @examples
 #' list_ekio_palettes()
 #' list_ekio_palettes("categorical")
 #' list_ekio_palettes("diverging")
-list_ekio_palettes <- function(type = "all") {
+#' list_ekio_palettes(verbose = TRUE)
+list_ekio_palettes <- function(type = "all", verbose = FALSE) {
   categorical <- c("cool", "minimal", "contrast", "full", "muted", "binary", "political")
   small_group <- c("duo_warm", "duo_cool", "trio_bold", "trio_cool", "quad_earth", "quad_vivid")
   scientific  <- c("okabe_ito", "viridis", "inferno", "plasma")
@@ -288,7 +293,7 @@ list_ekio_palettes <- function(type = "all") {
     ))
   }
 
-  switch(type,
+  result <- switch(type,
     categorical = categorical,
     small_group = small_group,
     scientific  = scientific,
@@ -302,6 +307,32 @@ list_ekio_palettes <- function(type = "all") {
       diverging   = diverging
     )
   )
+
+  if (verbose) {
+    cli::cli_h1("Available Palettes")
+
+    cli::cli_h2("Categorical")
+    cli::cli_text("{.val {categorical}}")
+
+    cli::cli_h2("Small Group Variants")
+    cli::cli_text("{.val {small_group}}")
+
+    cli::cli_h2("Scientific")
+    cli::cli_text("{.val {scientific}}")
+
+    cli::cli_h2("Sequential (for continuous scales)")
+    cli::cli_text("{.val {sequential}}")
+
+    cli::cli_h2("Diverging (for continuous scales)")
+    cli::cli_text("{.val {diverging}}")
+
+    cli::cli_text("")
+    cli::cli_alert_info("Use {.code show_ekio_palette(\"name\")} to visualize")
+
+    invisible(result)
+  } else {
+    result
+  }
 }
 
 # ---- Palette Visualization ----
@@ -358,36 +389,18 @@ show_ekio_palette <- function(palette, n = NULL, labels = TRUE) {
 
 #' Show All Palettes
 #'
-#' Lists all available palettes organized by type.
+#' @description
+#' Deprecated. Use [list_ekio_palettes()] with `verbose = TRUE` instead.
 #'
 #' @return NULL (invisibly). Prints palette information to console.
 #' @export
 #'
 #' @examples
-#' show_all_ekio_palettes()
+#' list_ekio_palettes(verbose = TRUE)
 show_all_ekio_palettes <- function() {
-
-  palettes <- list_ekio_palettes("all")
-
-  cli::cli_h1("Available Palettes")
-
-  cli::cli_h2("Categorical")
-  cli::cli_text("{.val {palettes$categorical}}")
-
-  cli::cli_h2("Small Group Variants")
-  cli::cli_text("{.val {palettes$small_group}}")
-
-  cli::cli_h2("Scientific")
-  cli::cli_text("{.val {palettes$scientific}}")
-
-  cli::cli_h2("Sequential (for continuous scales)")
-  cli::cli_text("{.val {palettes$sequential}}")
-
-  cli::cli_h2("Diverging (for continuous scales)")
-  cli::cli_text("{.val {palettes$diverging}}")
-
-  cli::cli_text("")
-  cli::cli_alert_info("Use {.code show_ekio_palette(\"name\")} to visualize")
-
-  invisible(NULL)
+  cli::cli_warn(c(
+    "{.fn show_all_ekio_palettes} was deprecated in ekioplot 0.6.0.",
+    "i" = "Use {.code list_ekio_palettes(verbose = TRUE)} instead."
+  ))
+  list_ekio_palettes(verbose = TRUE)
 }

--- a/R/colors.R
+++ b/R/colors.R
@@ -266,8 +266,8 @@ ekio_pal <- function(palette = "contrast", n = NULL, reverse = FALSE) {
 #' @param type Character. Type of palettes to list:
 #'   "categorical", "small_group", "scientific", "sequential", "diverging",
 #'   or "all" (default).
-#' @param verbose Logical. If TRUE, prints a formatted summary organized by
-#'   type instead of returning a value (default: FALSE).
+#' @param verbose Logical. If TRUE, prints a formatted summary of the
+#'   selected type(s) and returns the result invisibly (default: FALSE).
 #'
 #' @return Character vector of palette names, or named list if type = "all".
 #'   Invisibly returned when \code{verbose = TRUE}.
@@ -293,46 +293,38 @@ list_ekio_palettes <- function(type = "all", verbose = FALSE) {
     ))
   }
 
-  result <- switch(type,
+  groups <- list(
     categorical = categorical,
     small_group = small_group,
     scientific  = scientific,
     sequential  = sequential,
-    diverging   = diverging,
-    all = list(
-      categorical = categorical,
-      small_group = small_group,
-      scientific  = scientific,
-      sequential  = sequential,
-      diverging   = diverging
-    )
+    diverging   = diverging
   )
 
+  result <- if (type == "all") groups else groups[[type]]
+
   if (verbose) {
+    headers <- c(
+      categorical = "Categorical",
+      small_group = "Small Group Variants",
+      scientific  = "Scientific",
+      sequential  = "Sequential (for continuous scales)",
+      diverging   = "Diverging (for continuous scales)"
+    )
+    shown <- if (type == "all") names(headers) else type
+
     cli::cli_h1("Available Palettes")
-
-    cli::cli_h2("Categorical")
-    cli::cli_text("{.val {categorical}}")
-
-    cli::cli_h2("Small Group Variants")
-    cli::cli_text("{.val {small_group}}")
-
-    cli::cli_h2("Scientific")
-    cli::cli_text("{.val {scientific}}")
-
-    cli::cli_h2("Sequential (for continuous scales)")
-    cli::cli_text("{.val {sequential}}")
-
-    cli::cli_h2("Diverging (for continuous scales)")
-    cli::cli_text("{.val {diverging}}")
-
+    for (nm in shown) {
+      cli::cli_h2(headers[[nm]])
+      cli::cli_text("{.val {groups[[nm]]}}")
+    }
     cli::cli_text("")
     cli::cli_alert_info("Use {.code show_ekio_palette(\"name\")} to visualize")
 
-    invisible(result)
-  } else {
-    result
+    return(invisible(result))
   }
+
+  result
 }
 
 # ---- Palette Visualization ----
@@ -392,15 +384,21 @@ show_ekio_palette <- function(palette, n = NULL, labels = TRUE) {
 #' @description
 #' Deprecated. Use [list_ekio_palettes()] with `verbose = TRUE` instead.
 #'
-#' @return NULL (invisibly). Prints palette information to console.
+#' @return The palette list, invisibly (as returned by
+#'   [list_ekio_palettes()] with `verbose = TRUE`).
+#' @keywords internal
 #' @export
 #'
 #' @examples
 #' list_ekio_palettes(verbose = TRUE)
 show_all_ekio_palettes <- function() {
-  cli::cli_warn(c(
-    "{.fn show_all_ekio_palettes} was deprecated in ekioplot 0.6.0.",
-    "i" = "Use {.code list_ekio_palettes(verbose = TRUE)} instead."
-  ))
+  cli::cli_warn(
+    c(
+      "{.fn show_all_ekio_palettes} was deprecated in ekioplot 0.6.0.",
+      "i" = "Use {.code list_ekio_palettes(verbose = TRUE)} instead."
+    ),
+    .frequency = "once",
+    .frequency_id = "show_all_ekio_palettes"
+  )
   list_ekio_palettes(verbose = TRUE)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,9 +84,9 @@ ekioplot ships ~30 palettes across five categories, all accessible through a
 single function:
 
 ```{r}
-list_ekio_palettes()        # explore everything, grouped by type
-ekio_pal("contrast")        # categorical
-ekio_pal("blue", n = 5)     # sequential, interpolated to 5 colors
+list_ekio_palettes() # explore everything, grouped by type
+ekio_pal("contrast") # categorical
+ekio_pal("blue", n = 5) # sequential, interpolated to 5 colors
 show_ekio_palette("contrast")
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ ekioplot ships ~30 palettes across five categories, all accessible
 through a single function:
 
 ``` r
-list_ekio_palettes()        # explore everything, grouped by type
-ekio_pal("contrast")        # categorical
-ekio_pal("blue", n = 5)     # sequential, interpolated to 5 colors
+list_ekio_palettes() # explore everything, grouped by type
+ekio_pal("contrast") # categorical
+ekio_pal("blue", n = 5) # sequential, interpolated to 5 colors
 show_ekio_palette("contrast")
 ```
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -36,7 +36,6 @@ reference:
       - ekio_pal
       - list_ekio_palettes
       - show_ekio_palette
-      - show_all_ekio_palettes
 
   - title: Color Scales
     desc: Named color vectors for direct use

--- a/man/list_ekio_palettes.Rd
+++ b/man/list_ekio_palettes.Rd
@@ -11,8 +11,8 @@ list_ekio_palettes(type = "all", verbose = FALSE)
 "categorical", "small_group", "scientific", "sequential", "diverging",
 or "all" (default).}
 
-\item{verbose}{Logical. If TRUE, prints a formatted summary organized by
-type instead of returning a value (default: FALSE).}
+\item{verbose}{Logical. If TRUE, prints a formatted summary of the
+selected type(s) and returns the result invisibly (default: FALSE).}
 }
 \value{
 Character vector of palette names, or named list if type = "all".

--- a/man/list_ekio_palettes.Rd
+++ b/man/list_ekio_palettes.Rd
@@ -4,21 +4,27 @@
 \alias{list_ekio_palettes}
 \title{List Available Palettes}
 \usage{
-list_ekio_palettes(type = "all")
+list_ekio_palettes(type = "all", verbose = FALSE)
 }
 \arguments{
 \item{type}{Character. Type of palettes to list:
 "categorical", "small_group", "scientific", "sequential", "diverging",
 or "all" (default).}
+
+\item{verbose}{Logical. If TRUE, prints a formatted summary organized by
+type instead of returning a value (default: FALSE).}
 }
 \value{
-Character vector of palette names, or named list if type = "all"
+Character vector of palette names, or named list if type = "all".
+Invisibly returned when \code{verbose = TRUE}.
 }
 \description{
 Returns names of all available palettes, optionally filtered by type.
+When \code{verbose = TRUE}, prints a formatted summary to the console.
 }
 \examples{
 list_ekio_palettes()
 list_ekio_palettes("categorical")
 list_ekio_palettes("diverging")
+list_ekio_palettes(verbose = TRUE)
 }

--- a/man/show_all_ekio_palettes.Rd
+++ b/man/show_all_ekio_palettes.Rd
@@ -10,8 +10,8 @@ show_all_ekio_palettes()
 NULL (invisibly). Prints palette information to console.
 }
 \description{
-Lists all available palettes organized by type.
+Deprecated. Use \code{\link[=list_ekio_palettes]{list_ekio_palettes()}} with \code{verbose = TRUE} instead.
 }
 \examples{
-show_all_ekio_palettes()
+list_ekio_palettes(verbose = TRUE)
 }

--- a/man/show_all_ekio_palettes.Rd
+++ b/man/show_all_ekio_palettes.Rd
@@ -7,7 +7,8 @@
 show_all_ekio_palettes()
 }
 \value{
-NULL (invisibly). Prints palette information to console.
+The palette list, invisibly (as returned by
+\code{\link[=list_ekio_palettes]{list_ekio_palettes()}} with \code{verbose = TRUE}).
 }
 \description{
 Deprecated. Use \code{\link[=list_ekio_palettes]{list_ekio_palettes()}} with \code{verbose = TRUE} instead.
@@ -15,3 +16,4 @@ Deprecated. Use \code{\link[=list_ekio_palettes]{list_ekio_palettes()}} with \co
 \examples{
 list_ekio_palettes(verbose = TRUE)
 }
+\keyword{internal}

--- a/tests/testthat/test-colors.R
+++ b/tests/testthat/test-colors.R
@@ -81,6 +81,29 @@ test_that("list_ekio_palettes returns correct structure", {
   expect_true("blue_orange" %in% list_ekio_palettes("diverging"))
 })
 
+test_that("list_ekio_palettes verbose prints summary and returns invisibly", {
+  out <- cli::cli_fmt(res <- withVisible(list_ekio_palettes(verbose = TRUE)))
+  expect_false(res$visible)
+  expect_identical(res$value, list_ekio_palettes())
+  expect_true(any(grepl("Available Palettes", out)))
+  expect_true(any(grepl("Diverging", out)))
+})
+
+test_that("list_ekio_palettes verbose respects the type filter", {
+  out <- cli::cli_fmt(res <- list_ekio_palettes("categorical", verbose = TRUE))
+  expect_identical(res, list_ekio_palettes("categorical"))
+  expect_true(any(grepl("Categorical", out)))
+  expect_false(any(grepl("Diverging|Sequential|Scientific", out)))
+})
+
+test_that("show_all_ekio_palettes warns about deprecation but still works", {
+  expect_warning(
+    res <- suppressMessages(show_all_ekio_palettes()),
+    "deprecated"
+  )
+  expect_identical(res, list_ekio_palettes())
+})
+
 test_that("color scale vectors exist and are valid", {
   expect_type(ekio_blue, "character")
   expect_true(length(ekio_blue) >= 9)


### PR DESCRIPTION
## Summary

- `show_all_ekio_palettes()` and `list_ekio_palettes()` did the same job through two entry points. Merges the console-summary behavior into `list_ekio_palettes(type, verbose = TRUE)` and deprecates the old function with a `cli::cli_warn()` pointing at the replacement.
- Documents brand color/type tokens in `CLAUDE.md` as the canonical source of truth for downstream projects (`ekio` workspace, `ekio-site`).

## Changes

- **R/colors.R** — `list_ekio_palettes()` gains `verbose` arg; `show_all_ekio_palettes()` now deprecated and delegates to it.
- **NEWS.md** — breaking-change entry under 0.6.0.
- **DESCRIPTION** — version `0.5.0` → `0.6.0`.
- **_pkgdown.yml** — drop `show_all_ekio_palettes` from reference index.
- **CLAUDE.md** — new "Brand tokens (canonical)" section.
- Regenerated `man/list_ekio_palettes.Rd`, `man/show_all_ekio_palettes.Rd`.

## Notes

- `R CMD check`: 0 errors / 0 warnings / 0 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)