### PR TITLE
docs(news): complete 0.5.0 release notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,22 @@
   `ggplot2`'s tree. Users who style `gt` tables should add `gt` to their own
   dependencies.
 
+* `ekio_scatterplot()` no longer forces a y = 0 baseline by default
+  (`add_zero = FALSE`). Scatter plots whose y values are far from zero were
+  distorted by the forced baseline. Pass `add_zero = TRUE` to restore the old
+  behavior.
+
+## Bug fixes
+
+* `ekio_histogram()` now handles transformed x expressions such as `log(mpg)`;
+  previously the bin calculation errored on anything other than a bare column
+  name.
+
+## Documentation
+
+* Replaced a dead Imazon reference URL in the `ips_brasil` dataset
+  documentation.
+
 # ekioplot 0.4.0
 
 ## Breaking changes


### PR DESCRIPTION
## Summary
Completes the 0.5.0 NEWS entry ahead of tagging the release. Adds the user-facing changes that were already merged to master but missing from NEWS.md: the breaking `ekio_scatterplot()` `add_zero = FALSE` default, the expression-safe `ekio_histogram()` bin calculation fix, and the `ips_brasil` documentation URL fix. No code changes.

## Verification
`devtools::check()` passes locally with 0 errors, 0 warnings, 1 ignorable note (`.git` directory). Rendered NEWS is visible in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)